### PR TITLE
Mapbox Navigation SDK for Android dependency version bump to 0.31.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     // Mapbox drop-in navigation UI library.
     // Adding this dependency automatically includes both the Mapbox Maps SDK for Android
     // and the Mapbox Navigation SDK for Android, which is why neither are listed in this file.
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-navigation-ui:0.30.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-navigation-ui:0.31.0'
 
     // Mapbox Services SDK dependency to retrieve routes from the Mapbox Directions API
     implementation 'com.mapbox.mapboxsdk:mapbox-sdk-services:4.5.0'

--- a/app/src/main/java/com/mapbox/mapboxgoshare/TurnByTurnNavigationFragment.java
+++ b/app/src/main/java/com/mapbox/mapboxgoshare/TurnByTurnNavigationFragment.java
@@ -99,7 +99,6 @@ public class TurnByTurnNavigationFragment extends android.app.Fragment
           NavigationViewOptions options = NavigationViewOptions.builder()
             .navigationListener(TurnByTurnNavigationFragment.this)
             .directionsRoute(response.body().routes().get(0))
-            .directionsProfile(PROFILE_WALKING)
             .shouldSimulateRoute(true)
               .build();
           navigationView.startNavigation(options);

--- a/app/src/main/java/com/mapbox/mapboxgoshare/VehicleMapFragment.java
+++ b/app/src/main/java/com/mapbox/mapboxgoshare/VehicleMapFragment.java
@@ -331,7 +331,6 @@ public class VehicleMapFragment extends Fragment implements
           public void onResponse(Call<DirectionsResponse> call, Response<DirectionsResponse> response) {
             NavigationLauncherOptions options = NavigationLauncherOptions.builder()
               .directionsRoute(response.body().routes().get(0))
-              .directionsProfile(PROFILE_WALKING)
               .shouldSimulateRoute(true)
               .build();
             view.findViewById(R.id.main_mapView).setVisibility(View.INVISIBLE);


### PR DESCRIPTION
This pr bumps the dependency of the Mapbox Navigation SDK for Android to 0.31.0 and makes necessary changes

More info about the 0.31.0 release: https://github.com/mapbox/mapbox-navigation-android/releases/tag/v0.31.0