### PR TITLE
Nav SDK bump to 0.34.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     // Mapbox drop-in navigation UI library.
     // Adding this dependency automatically includes both the Mapbox Maps SDK for Android
     // and the Mapbox Navigation SDK for Android, which is why neither are listed in this file.
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-navigation-ui:0.31.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-navigation-ui:0.34.0'
 
     // Mapbox Services SDK dependency to retrieve routes from the Mapbox Directions API
     implementation 'com.mapbox.mapboxsdk:mapbox-sdk-services:4.5.0'

--- a/app/src/main/java/com/mapbox/mapboxgoshare/MainActivity.java
+++ b/app/src/main/java/com/mapbox/mapboxgoshare/MainActivity.java
@@ -16,7 +16,6 @@ import android.view.MenuItem;
 public class MainActivity extends AppCompatActivity implements
   android.support.design.widget.NavigationView.OnNavigationItemSelectedListener {
 
-  private static String TAG = "MainActivity";
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);

--- a/app/src/main/res/layout/nav_header_main.xml
+++ b/app/src/main/res/layout/nav_header_main.xml
@@ -23,13 +23,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingTop="@dimen/nav_header_vertical_spacing"
-        android:text="Mapbox GoShare"
+        android:text="@string/title_activity_map"
         android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
-
-    <TextView
-        android:id="@+id/textView"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/navigation_drawer_description" />
 
 </LinearLayout>


### PR DESCRIPTION
This pr bumps the app's Mapbox Navigation SDK dependency [to the latest version; `0.34.0`](https://github.com/mapbox/mapbox-navigation-android/issues/1860). This also transitively updates the Maps SDK version to `7.3.0` because the Nav SDK includes the Maps SDK.

