### PR TITLE
Places plugin 0.8.0 and localization plugin 0.9.0 dependency bump

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,9 +38,6 @@ dependencies {
     // and the Mapbox Navigation SDK for Android, which is why neither are listed in this file.
     implementation 'com.mapbox.mapboxsdk:mapbox-android-navigation-ui:0.34.0'
 
-    // Mapbox Services SDK dependency to retrieve routes from the Mapbox Directions API
-    implementation 'com.mapbox.mapboxsdk:mapbox-sdk-services:4.5.0'
-
     // Mapbox Turf library dependency to use distance calculation methods
     implementation 'com.mapbox.mapboxsdk:mapbox-sdk-turf:4.5.0'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,10 +48,10 @@ dependencies {
     implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-building-v7:0.5.0'
 
     // Mapbox Places Plugin to make geocoding requests
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-places-v7:0.7.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-places-v7:0.8.0'
 
     // Mapbox Localization Plugin to adjust map text to match the device's set language
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v7:0.8.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v7:0.9.0'
 
 }
 apply from: "${rootDir}/gradle/checkstyle.gradle"


### PR DESCRIPTION
This pr bumps the app's dependencies for the Mapbox Places plugin and Localization plugin, which is part of their release process: https://github.com/mapbox/mapbox-plugins-android/issues/914

This pr also removes the separate dependency declaration for the Mapbox Java SDK's services module. This is included in the Mapbox Navigation SDK for Android, which the app uses.